### PR TITLE
Fix Issue 132, crash when navigating back without stopping drum seque…

### DIFF
--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/MiniApps/DrumSequencer.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/MiniApps/DrumSequencer.swift
@@ -119,6 +119,7 @@ struct DrumSequencerView: View {
             conductor.start()
         }
         .onDisappear {
+            conductor.drums.destroyEndpoint()
             conductor.stop()
         }
     }


### PR DESCRIPTION
This fixes issue #132 I reported earlier.

When navigating back from the Drum sequencer mini app without stopping, the app crashed.

This fix cuts the MIDI connection before (as far as I understand the underlying method) eventually making it crash-free.